### PR TITLE
fix(ui): corrigir borda arredondada do menu lateral quando estático

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <div class="po-wrapper">
   <!-- Layout com menu -->
-  <div class="h-screen overflow-hidden" *ngIf="shouldShowMenu()">
+  <div class="h-screen overflow-hidden bg-gradient-to-br from-[#1A4E79] to-[#75C9C8]" *ngIf="shouldShowMenu()">
     <app-menu (menuToggled)="onMenuToggled($event)"></app-menu>
     <div class="h-full overflow-hidden transition-all duration-300"
          [class.ml-16]="menuCollapsed && !isMobile"

--- a/src/app/shared/menu/menu.component.ts
+++ b/src/app/shared/menu/menu.component.ts
@@ -227,7 +227,7 @@ export class MenuComponent implements OnInit, OnDestroy {
             submenus: [
             //  { id: menu.id, label: 'Viagens', icon: 'airplane', link: '/financeiro/viagens' },
               { id: menu.id, label: 'Prestação de Contas',  icon: 'calculator', link: '/financeiro/prestacao-contas'   },
-              { id: menu.id, label: 'Minhas Prestações',    icon: 'list',       link: '/financeiro/minhas-prestacoes'  }
+              { id: menu.id, label: 'Minhas Prestações',    icon: 'an an-address-book-tabs',       link: '/financeiro/minhas-prestacoes'  }
             ]
           };
           menuMap.set('financeiro', financeiroMenu);


### PR DESCRIPTION
Adicionado gradient de fundo no wrapper do layout para que o recorte das bordas arredondadas do sidebar seja sempre visível — antes, a área de recorte mostrava o fundo branco (igual ao sidebar), tornando os cantos invisíveis exceto durante animações de transição.